### PR TITLE
Fix for PerformCalculations method at DeadlockSample class

### DIFF
--- a/chapter03/DeadlockAndRaceSample.cs
+++ b/chapter03/DeadlockAndRaceSample.cs
@@ -91,8 +91,8 @@ public class DeadlockSample
     public async Task PerformCalculations()
     {
         _runningTotal = 3;
-        await MultiplyValue().ContinueWith(async (Task) => {
-            await AddValue();
+        await MultiplyValue().ContinueWith((Task) => {
+            AddValue().Wait();
             });
         Console.WriteLine($"Running total is {_runningTotal}");
     }


### PR DESCRIPTION
Hi Alvin, I was reading your awesome book and noticed that although the book says that method PerformCalculations should "always end with _runningTotal equal to 45", actual output string was saying that _runningTotal is equal to 30.  

It seems to me that there is a little bug. Please see if we can fix the code this way. 